### PR TITLE
setState em App

### DIFF
--- a/projeto/src/components/Stopwatch/index.tsx
+++ b/projeto/src/components/Stopwatch/index.tsx
@@ -1,29 +1,19 @@
 import { TimerView } from '../TimerView/index'
-import { date } from '../../common/utils/date'
 import './style.scss'
 
 interface IStopwatchProps {
   time: number;
-  setTime: React.Dispatch<React.SetStateAction<number>>;
-  onFinish:() => void;
+  initiateCountdown:() => Promise<void>;
 }
 
 export function Stopwatch(props: IStopwatchProps){
   
-  async function handleOnClick() {
-    for (let i = 1; i <= props.time; i++) {
-      await date.delay()
-      props.setTime((prevState) => prevState - 1)
-    }
-    props.onFinish()
-  }
-
   return (
     <div className="cronometro">
       <div className="relogio-wrapper">
         <TimerView totalSeconds={props.time}/>
       </div>
-      <button onClick={handleOnClick}>Começar</button>
+      <button onClick={props.initiateCountdown}>Começar</button>
     </div>
   )
 }

--- a/projeto/src/pages/App.tsx
+++ b/projeto/src/pages/App.tsx
@@ -38,10 +38,18 @@ function App() {
     }
   }
 
+  async function initiateCountdown() {
+    for (let i = 1; i <= time; i++) {
+      await date.delay()
+      setTime((prevState) => prevState - 1)
+    }
+    handleOnFinish()
+  }
+
   return (
     <div className="App">
       <Form saveTask={handleSaveTask}/>
-      <Stopwatch time={time} setTime={setTime} onFinish={handleOnFinish}/>
+      <Stopwatch time={time} initiateCountdown={initiateCountdown}/>
       <List list={list} onClick={handleOnClick}/>
     </div>
   );


### PR DESCRIPTION
Alteração referente à solicitação:

**Não passar a referência do setState pra um componente filho  (src/components/Stopwatch/index.tsx Linha 5) por 2 motivos:**

 - Amarra a assinatura com o pai. Apesar de ser apenas um number pode criar um senso errado no aluno.

 - Pra passar o setState como referência é necessário o uso de Generics do Typescript. Vamos evitar usar isso pois como o curso é de React já com TS o generics pode gerar dificuldades.